### PR TITLE
validate proper 'od' and 'ld' when replacing or deleting to ensure nothing is inadvertently lost.

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 /*
  This is the implementation of the JSON OT type.
 
@@ -231,7 +232,19 @@ json.apply = function(snapshot, op) {
     else if (c.oi !== void 0) {
       json.checkObj(elem);
 
-      // Should check that elem[key] == c.od
+      if (c.od && elem[key]) {
+        // `od` + `oi` means replace or update. If the old value
+        // does not equal the current value, there was an error
+        // in the transformation.
+        assert.deepEqual(elem[key], c.od, "Deleting the wrong object.")
+      }
+
+      if (elem[key] && !c.od) {
+        // the operation is overwriting data but not updating the data. The old
+        // value that is being replaced needs to be included in the `od`.
+        throw new Error("Cannot overwrite data w/out replacing it.");
+      }
+
       elem[key] = c.oi;
     }
 

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -209,6 +209,8 @@ json.apply = function(snapshot, op) {
       json.checkList(elem);
       json.checkInRange(key, elem.length-1, 'delete');
 
+      assert.deepEqual(elem[key], c.ld, "Deleting the wrong object from the list.")
+
       // Should check the list element matches c.ld here too.
       elem.splice(key,1);
     }

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -234,14 +234,14 @@ json.apply = function(snapshot, op) {
     else if (c.oi !== void 0) {
       json.checkObj(elem);
 
-      if (c.od && elem[key]) {
+      if ('od' in c) {
         // `od` + `oi` means replace or update. If the old value
         // does not equal the current value, there was an error
         // in the transformation.
         assert.deepEqual(elem[key], c.od, "Deleting the wrong object.")
       }
 
-      if (elem[key] && !c.od) {
+      if ((key in elem) && !('od' in c)) {
         // the operation is overwriting data but not updating the data. The old
         // value that is being replaced needs to be included in the `od`.
         throw new Error("Cannot overwrite data w/out replacing it.");


### PR DESCRIPTION
The object replace operation includes both `oi` and `od`. If `od` is omitted, it can lead to transformation bugs. And more importantly, verifying that the existing data matches `od` is a great way to detect divergence.

This PR adds validation if the data is being overwritten via `oi`, then operation includes `od` and that the data being overwritten matches the data in `od`.

I don't want to merge this yet since we still have many clients who are not submitting `od` with their operations.

Edit: Also added checks for `ld` for the same reasons.
